### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/Brandon02/1e7bdacb-2c7c-4cc2-a4b1-c9fbbf69beab/4912fc1a-e62e-40d9-9dff-ac7de1bd3872/_apis/work/boardbadge/16f96193-b0d6-487a-bf7e-b5cdf306db2f)](https://dev.azure.com/Brandon02/1e7bdacb-2c7c-4cc2-a4b1-c9fbbf69beab/_boards/board/t/4912fc1a-e62e-40d9-9dff-ac7de1bd3872/Microsoft.RequirementCategory)
 icloud-bypass-server
 ====================
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Brandon02/1e7bdacb-2c7c-4cc2-a4b1-c9fbbf69beab/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.